### PR TITLE
Stop hiding some of the lint warnings

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -59,8 +59,6 @@ android {
         ignoreWarnings false
         textReport true
         textOutput 'stdout'
-        disable("InvalidPackage", "MissingPrefix", "UnusedAttribute", "UnknownIdInLayout", "InconsistentLayout",
-                "IconMissingDensityFolder", "Overdraw", "IconDensities", "GradleDependency")
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ allprojects {
         jcenter()
         google()
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
This PR removes globally disabled lint warning types while still keeping `SuppressWarnings`.